### PR TITLE
Add test for Cochran indicator when condition is satisfied

### DIFF
--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -109,6 +109,44 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         table = Table.from_list(Domain([a, b]), list(zip("yynny", "ynyyn")))
         chi = ChiSqStats(table, 0, 1)
         self.assertFalse(isnan(chi.chisq))
+    
+    def test_cochran_indicator_passes(self):
+        # Truly balanced 3x3: all expected frequencies >= 5
+        a = DiscreteVariable("A", values=("a1", "a2", "a3"))
+        b = DiscreteVariable("B", values=("b1", "b2", "b3"))
+    
+        # 60 cases total, balanced by rows and columns
+        # Row totals: 20, 20, 20
+        # Col totals: 20, 20, 20
+        # Expected per cell: (20*20)/60 = 6.666...  >= 5
+        rows = ["a1"] * 20 + ["a2"] * 20 + ["a3"] * 20
+        cols = ["b1"] * 20 + ["b2"] * 20 + ["b3"] * 20
+    
+        table = Table.from_list(Domain([a, b]), list(zip(rows, cols)))
+    
+        self.send_signal(self.widget.Inputs.data, table)
+        # Force attributes and trigger computation
+        self.widget.attr_x, self.widget.attr_y = a, b
+        self.widget.update_graph()
+    
+        # Cochran’s rule should be satisfied
+        self.assertTrue(getattr(self.widget, "_cochran_ok", None))
+        
+    def test_cochran_indicator_fails(self):
+        # Highly unbalanced 3x3 contingency table -> many expected < 5, some near 0
+        a = DiscreteVariable("A", values=("a1", "a2", "a3"))
+        b = DiscreteVariable("B", values=("b1", "b2", "b3"))
+        # 12 cases in total, 10 concentrated in a single cell
+        rows = ["a1"]*10 + ["a2"]*1 + ["a3"]*1
+        cols = ["b1"]*10 + ["b2"]*1 + ["b3"]*1
+        table = Table.from_list(Domain([a, b]), list(zip(rows, cols)))
+        
+        self.send_signal(self.widget.Inputs.data, table)
+        self.widget.attr_x, self.widget.attr_y = a, b
+        self.widget.update_graph()
+        
+        # Cochran’s rule should NOT be satisfied
+        self.assertFalse(getattr(self.widget, "_cochran_ok", True))
 
     def test_metadata(self):
         """


### PR DESCRIPTION
Introduced a new unit test that checks the Cochran’s rule indicator in the Sieve widget. The test uses a balanced 3x3 contingency table, where all expected frequencies are greater than 5, ensuring that the Cochran condition is satisfied. This verifies that the widget correctly sets the internal flag and displays the green indicator.

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
